### PR TITLE
Upgrade to ChromaDB 1.5.9 with bug fixes and thread safety

### DIFF
--- a/.github/workflows/build-nuget.yaml
+++ b/.github/workflows/build-nuget.yaml
@@ -30,11 +30,6 @@ jobs:
             artifact_suffix: win-x64
             lib_name: chroma_csharp.dll
             dll_search_name: chroma_csharp # For NativeMethods.cs loading
-          - os: macos-13
-            target: x86_64-apple-darwin
-            artifact_suffix: osx-x64
-            lib_name: libchroma_csharp.dylib
-            dll_search_name: chroma_csharp # For NativeMethods.cs loading
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact_suffix: osx-arm64
@@ -53,7 +48,7 @@ jobs:
         sudo apt-get install -y protobuf-compiler libsqlite3-dev
 
     - name: Install Dependencies (macOS)
-      if: matrix.os == 'macos-latest' || matrix.os == 'macos-13'
+      if: matrix.os == 'macos-latest'
       run: |
         brew install protobuf sqlite
 
@@ -63,7 +58,7 @@ jobs:
         choco install protoc SQLite --yes
         
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.92.0
       with:
         targets: ${{ matrix.target }}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,16 @@ name = "chroma_csharp"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-chroma-frontend = { git = "https://github.com/chroma-core/chroma.git", tag = "1.0.15", package = "chroma-frontend" }
-chroma-cache = { git = "https://github.com/chroma-core/chroma.git", tag = "1.0.15", package = "chroma-cache" }
-chroma-config = { git = "https://github.com/chroma-core/chroma.git", tag = "1.0.15", package = "chroma-config" }
-chroma-log = { git = "https://github.com/chroma-core/chroma.git", tag = "1.0.15", package = "chroma-log" }
-chroma-segment = { git = "https://github.com/chroma-core/chroma.git",  tag = "1.0.15", package = "chroma-segment" }
-chroma-sqlite = { git = "https://github.com/chroma-core/chroma.git", tag = "1.0.15", package = "chroma-sqlite" }
-chroma-sysdb = { git = "https://github.com/chroma-core/chroma.git", tag = "1.0.15", package = "chroma-sysdb" }
-chroma-system = { git = "https://github.com/chroma-core/chroma.git", tag = "1.0.15", package = "chroma-system" }
-chroma-types = { git = "https://github.com/chroma-core/chroma.git", tag = "1.0.15", package = "chroma-types" }
-chroma-error = { git = "https://github.com/chroma-core/chroma.git",  tag = "1.0.15", package = "chroma-error" }
-syn = "2.0.104"
+chroma-frontend = { git = "https://github.com/chroma-core/chroma.git", tag = "1.5.9", package = "chroma-frontend" }
+chroma-cache = { git = "https://github.com/chroma-core/chroma.git", tag = "1.5.9", package = "chroma-cache" }
+chroma-config = { git = "https://github.com/chroma-core/chroma.git", tag = "1.5.9", package = "chroma-config" }
+chroma-log = { git = "https://github.com/chroma-core/chroma.git", tag = "1.5.9", package = "chroma-log" }
+chroma-segment = { git = "https://github.com/chroma-core/chroma.git", tag = "1.5.9", package = "chroma-segment" }
+chroma-sqlite = { git = "https://github.com/chroma-core/chroma.git", tag = "1.5.9", package = "chroma-sqlite" }
+chroma-sysdb = { git = "https://github.com/chroma-core/chroma.git", tag = "1.5.9", package = "chroma-sysdb" }
+chroma-system = { git = "https://github.com/chroma-core/chroma.git", tag = "1.5.9", package = "chroma-system" }
+chroma-types = { git = "https://github.com/chroma-core/chroma.git", tag = "1.5.9", package = "chroma-types" }
+chroma-error = { git = "https://github.com/chroma-core/chroma.git", tag = "1.5.9", package = "chroma-error" }
 
 # FFI dependencies
 libc = "0.2"
@@ -29,7 +28,7 @@ serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 tokio = { version = "1.41", features = ["full", "fs", "macros", "rt-multi-thread"] }
 uuid = { version = "1.11.0", features = ["v4", "fast-rng", "macro-diagnostics", "serde"] }
-chrono = { version = "=0.4.38", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde"] }
 
 # For error handling
 thiserror = "1.0.69"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chromadb-dotnet-bindings"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Native Bindings for ChromaDB.NET"
 license = "Apache-2.0"

--- a/ChromaDB.NET/ChromaClient.cs
+++ b/ChromaDB.NET/ChromaClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.Json;
+using System.Threading;
 
 namespace ChromaDB.NET;
 
@@ -12,11 +13,8 @@ namespace ChromaDB.NET;
 public class ChromaClient : IDisposable
 {
     private IntPtr _handle;
-    private bool _disposed = false;
+    private int _disposed;
 
-    /// <summary>
-    /// Helper method to marshal a native ChromaError to a managed ChromaErrorInfo
-    /// </summary>
     internal static ChromaErrorInfo MarshalError(IntPtr errorPtr)
     {
         if (errorPtr == IntPtr.Zero)
@@ -39,9 +37,6 @@ public class ChromaClient : IDisposable
         return new ChromaErrorInfo(nativeError.Code, message, source, details);
     }
 
-    /// <summary>
-    /// Helper method to check for errors and throw exceptions if needed
-    /// </summary>
     internal static void CheckError(int errorCode, IntPtr errorPtr)
     {
         if (errorCode == 0) // Success
@@ -77,55 +72,32 @@ public class ChromaClient : IDisposable
         CheckError(result, errorPtr);
     }
 
-    /// <summary>
-    /// Creates a new collection
-    /// </summary>
-    /// <param name="name">Collection name</param>
-    /// <param name="embeddingFunction">Function to generate embeddings</param>
-    /// <param name="metadata">Collection metadata</param>
-    /// <returns>A Collection object</returns>
     public Collection CreateCollection(string name, IEmbeddingFunction embeddingFunction = null, Dictionary<string, object> metadata = null)
     {
         return CreateOrGetCollection(name, false, embeddingFunction, metadata);
     }
 
-    /// <summary>
-    /// Creates a new collection or gets an existing one
-    /// </summary>
-    /// <param name="name">Collection name</param>
-    /// <param name="embeddingFunction">Function to generate embeddings</param>
-    /// <param name="metadata">Collection metadata</param>
-    /// <returns>A Collection object</returns>
     public Collection CreateOrGetCollection(string name, IEmbeddingFunction embeddingFunction = null, Dictionary<string, object> metadata = null)
     {
         return CreateOrGetCollection(name, true, embeddingFunction, metadata);
     }
 
-    /// <summary>
-    /// Creates a new collection or gets an existing one
-    /// </summary>
-    /// <param name="name">Collection name</param>
-    /// <param name="getOrCreate">Whether to get an existing collection if it exists</param>
-    /// <param name="embeddingFunction">Function to generate embeddings</param>
-    /// <param name="metadata">Collection metadata</param>
-    /// <returns>A Collection object</returns>
     private Collection CreateOrGetCollection(string name, bool getOrCreate, IEmbeddingFunction embeddingFunction = null, Dictionary<string, object> metadata = null)
     {
+        var handle = GetHandleOrThrow();
+
         string configJson = null;
         if (embeddingFunction != null)
         {
-            // The Rust core expects the configuration JSON to directly represent
-            // the embedding function's config, including its 'type'.
-            // We should serialize the Configuration object directly, not wrap it.
             configJson = JsonSerializer.Serialize(embeddingFunction.Configuration);
         }
 
         string metadataJson = metadata != null ? JsonSerializer.Serialize(metadata) : null;
 
         var result = NativeMethods.chroma_create_collection(
-            _handle,
+            handle,
             name,
-            configJson, // Pass the direct configuration JSON
+            configJson,
             metadataJson,
             getOrCreate,
             null,
@@ -138,16 +110,12 @@ public class ChromaClient : IDisposable
         return new Collection(this, collectionHandle, embeddingFunction);
     }
 
-    /// <summary>
-    /// Gets an existing collection
-    /// </summary>
-    /// <param name="name">Collection name</param>
-    /// <param name="embeddingFunction">Function to generate embeddings</param>
-    /// <returns>A Collection object</returns>
     public Collection GetCollection(string name, IEmbeddingFunction embeddingFunction = null)
     {
+        var handle = GetHandleOrThrow();
+
         var result = NativeMethods.chroma_get_collection(
-            _handle,
+            handle,
             name,
             null,
             null,
@@ -159,47 +127,33 @@ public class ChromaClient : IDisposable
         return new Collection(this, collectionHandle, embeddingFunction);
     }
 
-    /// <summary>
-    /// Gets or creates a collection with the specified name
-    /// </summary>
-    /// <param name="name">Collection name</param>
-    /// <param name="embeddingFunction">Function to generate embeddings</param>
-    /// <param name="metadata">Collection metadata (only used if creating)</param>
-    /// <returns>A Collection object</returns>
     public Collection GetOrCreateCollection(string name, IEmbeddingFunction embeddingFunction = null, Dictionary<string, object> metadata = null)
     {
         try
         {
             return GetCollection(name, embeddingFunction);
         }
-        catch (ChromaException)
+        catch (ChromaException ex) when (ex.ErrorInfo.Code == ChromaErrorCode.NotFound)
         {
             return CreateCollection(name, embeddingFunction, metadata);
         }
     }
 
-    /// <summary>
-    /// Gets a heartbeat from the server
-    /// </summary>
-    /// <returns>Current timestamp</returns>
     public ulong Heartbeat()
     {
-        var result = NativeMethods.chroma_heartbeat(_handle, out var timestamp, out var errorPtr);
+        var handle = GetHandleOrThrow();
+        var result = NativeMethods.chroma_heartbeat(handle, out var timestamp, out var errorPtr);
 
         CheckError(result, errorPtr);
 
         return timestamp;
     }
 
-    /// <summary>
-    /// Creates a database in ChromaDB
-    /// </summary>
-    /// <param name="name">Database name</param>
-    /// <param name="tenant">Optional tenant name</param>
     public void CreateDatabase(string name, string tenant = null)
     {
+        var handle = GetHandleOrThrow();
         var result = NativeMethods.chroma_create_database(
-            _handle,
+            handle,
             name,
             tenant,
             out var errorPtr);
@@ -207,16 +161,11 @@ public class ChromaClient : IDisposable
         CheckError(result, errorPtr);
     }
 
-    /// <summary>
-    /// Gets a database ID
-    /// </summary>
-    /// <param name="name">Database name</param>
-    /// <param name="tenant">Optional tenant name</param>
-    /// <returns>Database ID</returns>
     public string GetDatabaseId(string name, string tenant = null)
     {
+        var handle = GetHandleOrThrow();
         var result = NativeMethods.chroma_get_database(
-            _handle,
+            handle,
             name,
             tenant,
             out var idPtr,
@@ -234,15 +183,11 @@ public class ChromaClient : IDisposable
         }
     }
 
-    /// <summary>
-    /// Deletes a database
-    /// </summary>
-    /// <param name="name">Database name</param>
-    /// <param name="tenant">Optional tenant name</param>
     public void DeleteDatabase(string name, string tenant = null)
     {
+        var handle = GetHandleOrThrow();
         var result = NativeMethods.chroma_delete_database(
-            _handle,
+            handle,
             name,
             tenant,
             out var errorPtr);
@@ -250,56 +195,46 @@ public class ChromaClient : IDisposable
         CheckError(result, errorPtr);
     }
 
-    /// <summary>
-    /// Disposes the client
-    /// </summary>
     public void Dispose()
     {
         Dispose(true);
         GC.SuppressFinalize(this);
     }
 
-    /// <summary>
-    /// Disposes the client
-    /// </summary>
     protected virtual void Dispose(bool disposing)
     {
-        if (!_disposed)
+        var handle = Interlocked.Exchange(ref _handle, IntPtr.Zero);
+        if (handle == IntPtr.Zero)
+            return;
+
+        Volatile.Write(ref _disposed, 1);
+
+        var result = NativeMethods.chroma_destroy_client(handle, out var errorPtr);
+
+        if (result != 0 && errorPtr != IntPtr.Zero)
         {
-            if (_handle != IntPtr.Zero)
+            try
             {
-                var result = NativeMethods.chroma_destroy_client(_handle, out var errorPtr);
-
-                // We don't throw exceptions in Dispose, but we should at least log any errors
-                if (result != 0 && errorPtr != IntPtr.Zero)
-                {
-                    try
-                    {
-                        var errorInfo = MarshalError(errorPtr);
-                        Console.Error.WriteLine($"Error disposing ChromaClient: {errorInfo}");
-                    }
-                    finally
-                    {
-                        NativeMethods.chroma_free_error(errorPtr);
-                    }
-                }
-
-                _handle = IntPtr.Zero;
+                var errorInfo = MarshalError(errorPtr);
+                Console.Error.WriteLine($"Error disposing ChromaClient: {errorInfo}");
             }
-            _disposed = true;
+            finally
+            {
+                NativeMethods.chroma_free_error(errorPtr);
+            }
         }
     }
 
-    /// <summary>
-    /// Finalizer
-    /// </summary>
     ~ChromaClient()
     {
         Dispose(false);
     }
 
-    /// <summary>
-    /// Gets the native handle
-    /// </summary>
-    internal IntPtr Handle => _handle;
+    internal IntPtr GetHandleOrThrow()
+    {
+        var handle = Volatile.Read(ref _handle);
+        if (handle == IntPtr.Zero)
+            throw new ObjectDisposedException(nameof(ChromaClient));
+        return handle;
+    }
 }

--- a/ChromaDB.NET/ChromaClient.cs
+++ b/ChromaDB.NET/ChromaClient.cs
@@ -13,7 +13,6 @@ namespace ChromaDB.NET;
 public class ChromaClient : IDisposable
 {
     private IntPtr _handle;
-    private int _disposed;
 
     internal static ChromaErrorInfo MarshalError(IntPtr errorPtr)
     {
@@ -206,8 +205,6 @@ public class ChromaClient : IDisposable
         var handle = Interlocked.Exchange(ref _handle, IntPtr.Zero);
         if (handle == IntPtr.Zero)
             return;
-
-        Volatile.Write(ref _disposed, 1);
 
         var result = NativeMethods.chroma_destroy_client(handle, out var errorPtr);
 

--- a/ChromaDB.NET/ChromaDB.NET.csproj
+++ b/ChromaDB.NET/ChromaDB.NET.csproj
@@ -4,9 +4,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <!-- NuGet Package Information -->
     <PackageId>ChromaDB.NET</PackageId>
     <Title>ChromaDB.NET</Title>
     <Description>C# bindings for ChromaDB, a vector database for AI applications</Description>
@@ -16,7 +16,6 @@
     <Version>0.3.0</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <!-- Make internals visible to test project -->
     <InternalsVisibleTo>ChromaDB.NET.Tests</InternalsVisibleTo>
   </PropertyGroup>
   <PropertyGroup>
@@ -26,21 +25,10 @@
   <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
-
   <ItemGroup>
-    <None Include="$(_NativeTargetDir)/runtimes/linux-x64/native/lib$(_LibName).so" Pack="true" PackagePath="runtimes/linux-x64/native/" />
-    <None Include="$(_NativeTargetDir)/runtimes/win-x64/native/$(_LibName).dll" Pack="true" PackagePath="runtimes/win-x64/native/" />
-    <None Include="$(_NativeTargetDir)/runtimes/osx-x64/native/lib$(_LibName).dylib" Pack="true" PackagePath="runtimes/osx-x64/native/" />
-    <None Include="$(_NativeTargetDir)/runtimes/osx-arm64/native/lib$(_LibName).dylib" Pack="true" PackagePath="runtimes/osx-arm64/native/" />
-    <!-- Add osx-arm64 if needed -->
-    <!-- <None Include="$(_NativeTargetDir)/aarch64-apple-darwin/release/lib$(_LibName).dylib" Pack="true" PackagePath="runtimes/osx-arm64/native/" /> -->
-  </ItemGroup>
-
-  <!-- Include the C# assembly itself in the lib folder -->
-  <ItemGroup>
-    <BuildOutputInPackage Include="$(OutputPath)$(AssemblyName).dll" PackagePath="lib/$(TargetFramework)/" />
-    <BuildOutputInPackage Include="$(OutputPath)$(AssemblyName).pdb" PackagePath="lib/$(TargetFramework)/" />
-    <BuildOutputInPackage Include="$(OutputPath)$(AssemblyName).xml" PackagePath="lib/$(TargetFramework)/" Condition="Exists('$(OutputPath)$(AssemblyName).xml')" />
+    <None Include="$(_NativeTargetDir)/runtimes/linux-x64/native/lib$(_LibName).so" Pack="true" PackagePath="runtimes/linux-x64/native/" Condition="Exists('$(_NativeTargetDir)/runtimes/linux-x64/native/lib$(_LibName).so')" />
+    <None Include="$(_NativeTargetDir)/runtimes/win-x64/native/$(_LibName).dll" Pack="true" PackagePath="runtimes/win-x64/native/" Condition="Exists('$(_NativeTargetDir)/runtimes/win-x64/native/$(_LibName).dll')" />
+    <None Include="$(_NativeTargetDir)/runtimes/osx-arm64/native/lib$(_LibName).dylib" Pack="true" PackagePath="runtimes/osx-arm64/native/" Condition="Exists('$(_NativeTargetDir)/runtimes/osx-arm64/native/lib$(_LibName).dylib')" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="8.0.6" />

--- a/ChromaDB.NET/ChromaDB.NET.csproj
+++ b/ChromaDB.NET/ChromaDB.NET.csproj
@@ -13,7 +13,7 @@
     <Authors>David Baker</Authors>
     <PackageTags>chroma;vector;database;embeddings;bindings;native</PackageTags>
     <RepositoryUrl>https://github.com/Quorka/ChromaDB.NET</RepositoryUrl>
-    <Version>0.2.2</Version>
+    <Version>0.3.0</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <!-- Make internals visible to test project -->

--- a/ChromaDB.NET/Collection.cs
+++ b/ChromaDB.NET/Collection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.Json;
+using System.Threading;
 
 namespace ChromaDB.NET
 {
@@ -13,14 +14,12 @@ namespace ChromaDB.NET
     public class Collection : IDisposable
     {
         private IntPtr _handle;
-        private bool _disposed = false;
         private readonly ChromaClient _client;
         private readonly IEmbeddingFunction _embeddingFunction;
 
         private static readonly JsonSerializerOptions WhereFilterSerializerOptions = new JsonSerializerOptions
         {
             Converters = { new WhereFilterConverter() }
-            // Add other options like PropertyNamingPolicy if needed
         };
 
         internal Collection(ChromaClient client, IntPtr handle, IEmbeddingFunction embeddingFunction)
@@ -30,15 +29,25 @@ namespace ChromaDB.NET
             _embeddingFunction = embeddingFunction;
         }
 
+        private (IntPtr clientHandle, IntPtr collectionHandle) GetHandlesOrThrow()
+        {
+            var clientHandle = _client.GetHandleOrThrow();
+            var collectionHandle = Volatile.Read(ref _handle);
+            if (collectionHandle == IntPtr.Zero)
+                throw new ObjectDisposedException(nameof(Collection));
+            return (clientHandle, collectionHandle);
+        }
+
         /// <summary>
         /// Gets the number of documents in the collection
         /// </summary>
         /// <returns>The document count</returns>
         public uint Count()
         {
+            var (clientHandle, collectionHandle) = GetHandlesOrThrow();
             var result = NativeMethods.chroma_count(
-                _client.Handle,
-                _handle,
+                clientHandle,
+                collectionHandle,
                 out uint count,
                 out var errorPtr);
 
@@ -56,7 +65,8 @@ namespace ChromaDB.NET
             if (docs.Count == 0)
                 return;
 
-            // Generate embeddings if needed
+            var (clientHandle, collectionHandle) = GetHandlesOrThrow();
+
             if (_embeddingFunction != null)
             {
                 var textsToEmbed = docs.Where(d => d.Embedding == null && !string.IsNullOrEmpty(d.Text))
@@ -96,8 +106,8 @@ namespace ChromaDB.NET
             try
             {
                 var result = NativeMethods.chroma_add(
-                    _client.Handle,
-                    _handle,
+                    clientHandle,
+                    collectionHandle,
                     idsPtr,
                     (UIntPtr)ids.Length,
                     embeddingsPtr,
@@ -137,6 +147,7 @@ namespace ChromaDB.NET
             bool includeDocuments = true,
             bool includeDistances = true)
         {
+            var (clientHandle, collectionHandle) = GetHandlesOrThrow();
             var whereFilterJson = whereFilter != null ? JsonSerializer.Serialize(whereFilter, WhereFilterSerializerOptions) : null;
 
             var embeddingPtr = Marshal.AllocHGlobal(queryEmbedding.Length * sizeof(float));
@@ -145,8 +156,8 @@ namespace ChromaDB.NET
             try
             {
                 var result = NativeMethods.chroma_query(
-                    _client.Handle,
-                    _handle,
+                    clientHandle,
+                    collectionHandle,
                     embeddingPtr,
                     (UIntPtr)queryEmbedding.Length,
                     (uint)nResults,
@@ -221,7 +232,8 @@ namespace ChromaDB.NET
             if (docs.Count == 0)
                 return;
 
-            // Generate embeddings if needed
+            var (clientHandle, collectionHandle) = GetHandlesOrThrow();
+
             if (_embeddingFunction != null)
             {
                 var textsToEmbed = docs.Where(d => d.Embedding == null && !string.IsNullOrEmpty(d.Text))
@@ -266,8 +278,8 @@ namespace ChromaDB.NET
             try
             {
                 var result = NativeMethods.chroma_update(
-                    _client.Handle,
-                    _handle,
+                    clientHandle,
+                    collectionHandle,
                     idsPtr,
                     (UIntPtr)ids.Length,
                     embeddingsPtr,
@@ -298,7 +310,8 @@ namespace ChromaDB.NET
             if (docs.Count == 0)
                 return;
 
-            // Generate embeddings if needed
+            var (clientHandle, collectionHandle) = GetHandlesOrThrow();
+
             if (_embeddingFunction != null)
             {
                 var textsToEmbed = docs.Where(d => d.Embedding == null && !string.IsNullOrEmpty(d.Text))
@@ -338,8 +351,8 @@ namespace ChromaDB.NET
             try
             {
                 var result = NativeMethods.chroma_upsert(
-                    _client.Handle,
-                    _handle,
+                    clientHandle,
+                    collectionHandle,
                     idsPtr,
                     (UIntPtr)ids.Length,
                     embeddingsPtr,
@@ -370,11 +383,10 @@ namespace ChromaDB.NET
             Dictionary<string, object>? whereFilter = null,
             string? whereDocument = null)
         {
-            // At least one of the parameters must be provided
             if (ids == null && whereFilter == null && whereDocument == null)
                 throw new ArgumentException("You must provide at least one of: ids, whereFilter, or whereDocument");
 
-            // Marshal IDs
+            var (clientHandle, collectionHandle) = GetHandlesOrThrow();
             IntPtr idsPtr = IntPtr.Zero;
             UIntPtr idsCount = UIntPtr.Zero;
 
@@ -394,8 +406,8 @@ namespace ChromaDB.NET
             try
             {
                 var result = NativeMethods.chroma_delete(
-                    _client.Handle,
-                    _handle,
+                    clientHandle,
+                    collectionHandle,
                     idsPtr,
                     idsCount,
                     whereFilterJson,
@@ -435,7 +447,8 @@ namespace ChromaDB.NET
             bool includeMetadatas = true,
             bool includeDocuments = true)
         {
-            // Marshal IDs
+            var (clientHandle, collectionHandle) = GetHandlesOrThrow();
+
             IntPtr idsPtr = IntPtr.Zero;
             UIntPtr idsCount = UIntPtr.Zero;
 
@@ -455,8 +468,8 @@ namespace ChromaDB.NET
             try
             {
                 var result = NativeMethods.chroma_get(
-                    _client.Handle,
-                    _handle,
+                    clientHandle,
+                    collectionHandle,
                     idsPtr,
                     idsCount,
                     whereFilterJson,
@@ -515,14 +528,14 @@ namespace ChromaDB.NET
         /// <returns>Query results</returns>
         public QueryResult Where(WhereFilter filter, uint limit = 0, uint offset = 0, bool includeEmbeddings = false)
         {
-            // Instead of directly using ToDictionary, serialize the filter using the custom converter
+            var (clientHandle, collectionHandle) = GetHandlesOrThrow();
             string whereFilterJson = JsonSerializer.Serialize(filter, WhereFilterSerializerOptions);
 
             try
             {
                 var result = NativeMethods.chroma_get(
-                    _client.Handle,
-                    _handle,
+                    clientHandle,
+                    collectionHandle,
                     IntPtr.Zero, // No specific IDs
                     UIntPtr.Zero,
                     whereFilterJson,
@@ -681,29 +694,23 @@ namespace ChromaDB.NET
         /// </summary>
         protected virtual void Dispose(bool disposing)
         {
-            if (!_disposed)
+            var handle = Interlocked.Exchange(ref _handle, IntPtr.Zero);
+            if (handle == IntPtr.Zero)
+                return;
+
+            var result = NativeMethods.chroma_destroy_collection(handle, out var errorPtr);
+
+            if (result != 0 && errorPtr != IntPtr.Zero)
             {
-                if (_handle != IntPtr.Zero)
+                try
                 {
-                    var result = NativeMethods.chroma_destroy_collection(_handle, out var errorPtr);
-
-                    // We don't throw exceptions in Dispose, but we should at least log any errors
-                    if (result != 0 && errorPtr != IntPtr.Zero)
-                    {
-                        try
-                        {
-                            var errorInfo = ChromaClient.MarshalError(errorPtr);
-                            Console.Error.WriteLine($"Error disposing ChromaCollection: {errorInfo}");
-                        }
-                        finally
-                        {
-                            NativeMethods.chroma_free_error(errorPtr);
-                        }
-                    }
-
-                    _handle = IntPtr.Zero;
+                    var errorInfo = ChromaClient.MarshalError(errorPtr);
+                    Console.Error.WriteLine($"Error disposing ChromaCollection: {errorInfo}");
                 }
-                _disposed = true;
+                finally
+                {
+                    NativeMethods.chroma_free_error(errorPtr);
+                }
             }
         }
 

--- a/ChromaDB.NET/NativeMethods.cs
+++ b/ChromaDB.NET/NativeMethods.cs
@@ -14,7 +14,7 @@ internal static class NativeMethods
     private const string DllName = "chroma_csharp";
 
     [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-    public static extern int chroma_free_error(IntPtr error);
+    public static extern void chroma_free_error(IntPtr error);
 
     [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     public static extern int chroma_create_client(

--- a/Tests/ChromaDB.NET.Tests/AdditionalCoverageTests.cs
+++ b/Tests/ChromaDB.NET.Tests/AdditionalCoverageTests.cs
@@ -1,0 +1,318 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ChromaDB.NET.Tests
+{
+    [TestClass]
+    public class AdditionalCoverageTests
+    {
+        private string _testDir = string.Empty;
+        private TestEmbeddingFunction _embeddingFunction = new TestEmbeddingFunction();
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _testDir = Path.Combine(Path.GetTempPath(), "chromadb-dotnet-tests", Guid.NewGuid().ToString());
+            Directory.CreateDirectory(_testDir);
+            _embeddingFunction = new TestEmbeddingFunction();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            try
+            {
+                if (Directory.Exists(_testDir))
+                {
+                    Thread.Sleep(100);
+                    Directory.Delete(_testDir, true);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error cleaning up test directory '{_testDir}': {ex.Message}");
+            }
+        }
+
+        [TestMethod]
+        public void Heartbeat_ReturnsNonZero()
+        {
+            using var client = new ChromaClient(persistDirectory: _testDir);
+            var heartbeat = client.Heartbeat();
+            Assert.IsTrue(heartbeat > 0, "Heartbeat should return a positive timestamp");
+        }
+
+        [TestMethod]
+        public void GetOrCreateCollection_NotFoundFallsBackToCreate()
+        {
+            using var client = new ChromaClient(persistDirectory: _testDir);
+            string name = $"new-collection-{Guid.NewGuid():N}".Substring(0, 30);
+
+            using var collection = client.GetOrCreateCollection(name, _embeddingFunction);
+            Assert.IsNotNull(collection);
+
+            collection.Add("doc1", "test", new Dictionary<string, object> { ["k"] = "v" });
+            Assert.AreEqual<uint>(1, collection.Count());
+        }
+
+        [TestMethod]
+        public void GetOrCreateCollection_ExistingCollection_ReturnsExisting()
+        {
+            using var client = new ChromaClient(persistDirectory: _testDir);
+            string name = $"existing-col-{Guid.NewGuid():N}".Substring(0, 30);
+
+            using var created = client.CreateCollection(name, _embeddingFunction);
+            created.Add("doc1", "test", new Dictionary<string, object> { ["k"] = "v" });
+
+            using var fetched = client.GetOrCreateCollection(name, _embeddingFunction);
+            Assert.AreEqual<uint>(1, fetched.Count());
+        }
+
+        [TestMethod]
+        public void BatchAdd_100Documents_Success()
+        {
+            using var client = new ChromaClient(persistDirectory: _testDir);
+            using var collection = client.CreateCollectionWithUniqueName(embeddingFunction: _embeddingFunction);
+
+            var docs = new List<ChromaDocument>();
+            for (int i = 0; i < 100; i++)
+            {
+                docs.Add(ChromaDocument.Create(
+                    $"doc-{i}",
+                    $"Document number {i} with some text content",
+                    new Dictionary<string, object>
+                    {
+                        ["index"] = i,
+                        ["batch"] = "test"
+                    }));
+            }
+
+            collection.Add(docs);
+            Assert.AreEqual<uint>(100, collection.Count());
+
+            var results = collection.Get(limit: 10, includeDocuments: true);
+            Assert.AreEqual(10, results.Ids.Count);
+        }
+
+        [TestMethod]
+        public void BatchAdd_ThenQuery_DistancesOrdered()
+        {
+            using var client = new ChromaClient(persistDirectory: _testDir);
+            using var collection = client.CreateCollectionWithUniqueName(embeddingFunction: new TestEmbeddingFunction(dimension: 8));
+
+            for (int i = 0; i < 20; i++)
+            {
+                collection.Add($"doc-{i}", $"Document {i}",
+                    new Dictionary<string, object> { ["i"] = i });
+            }
+
+            var results = collection.Query(queryText: "Document 0", nResults: 5, includeDistances: true);
+
+            Assert.AreEqual(5, results.Ids.Count);
+            Assert.AreEqual(5, results.Distances.Count);
+
+            for (int i = 1; i < results.Distances.Count; i++)
+            {
+                Assert.IsTrue(results.Distances[i] >= results.Distances[i - 1],
+                    $"Distances should be non-decreasing: [{i-1}]={results.Distances[i-1]} > [{i}]={results.Distances[i]}");
+            }
+        }
+
+        [TestMethod]
+        public void Update_NonExistentDocument_DoesNotThrow()
+        {
+            using var client = new ChromaClient(persistDirectory: _testDir);
+            using var collection = client.CreateCollectionWithUniqueName(embeddingFunction: _embeddingFunction);
+
+            collection.Add("existing", "some text",
+                new Dictionary<string, object> { ["k"] = "v" });
+
+            // ChromaDB silently ignores updates for non-existent IDs
+            collection.Update("does-not-exist", "update attempt");
+
+            Assert.AreEqual<uint>(1, collection.Count());
+            var doc = collection.GetById("existing");
+            Assert.AreEqual("some text", doc.Text);
+        }
+
+        [TestMethod]
+        public void WhereFilter_NotEquals_IntegrationTest()
+        {
+            using var client = new ChromaClient(persistDirectory: _testDir);
+            using var collection = client.CreateCollectionWithUniqueName(embeddingFunction: _embeddingFunction);
+
+            collection.Add("doc1", "Cat", new Dictionary<string, object> { ["animal"] = "cat" });
+            collection.Add("doc2", "Dog", new Dictionary<string, object> { ["animal"] = "dog" });
+            collection.Add("doc3", "Bird", new Dictionary<string, object> { ["animal"] = "bird" });
+
+            var filter = new Dictionary<string, object>
+            {
+                ["animal"] = new Dictionary<string, object> { ["$ne"] = "cat" }
+            };
+
+            var results = collection.Get(whereFilter: filter);
+            Assert.AreEqual(2, results.Ids.Count);
+            Assert.IsFalse(results.Ids.Contains("doc1"));
+            Assert.IsTrue(results.Ids.Contains("doc2"));
+            Assert.IsTrue(results.Ids.Contains("doc3"));
+        }
+
+        [TestMethod]
+        public void Query_WithWhereDocumentFilter()
+        {
+            using var client = new ChromaClient(persistDirectory: _testDir);
+            using var collection = client.CreateCollectionWithUniqueName(embeddingFunction: _embeddingFunction);
+
+            collection.Add("doc1", "The quick brown fox jumps over the lazy dog",
+                new Dictionary<string, object> { ["source"] = "test" });
+            collection.Add("doc2", "Artificial intelligence is transforming the world",
+                new Dictionary<string, object> { ["source"] = "test" });
+            collection.Add("doc3", "The fox ran across the field",
+                new Dictionary<string, object> { ["source"] = "test" });
+
+            var results = collection.Query(
+                queryText: "fox",
+                nResults: 10,
+                whereDocument: "{\"$contains\": \"fox\"}",
+                includeDocuments: true);
+
+            Assert.IsTrue(results.Ids.Count >= 1);
+            foreach (var doc in results.Documents)
+            {
+                Assert.IsTrue(doc.Contains("fox", StringComparison.OrdinalIgnoreCase),
+                    $"Document should contain 'fox': {doc}");
+            }
+        }
+
+        [TestMethod]
+        public void Get_WithPagination_ReturnsCorrectSubset()
+        {
+            using var client = new ChromaClient(persistDirectory: _testDir);
+            using var collection = client.CreateCollectionWithUniqueName(embeddingFunction: _embeddingFunction);
+
+            for (int i = 0; i < 10; i++)
+            {
+                collection.Add($"doc-{i:D2}", $"Document {i}",
+                    new Dictionary<string, object> { ["i"] = i });
+            }
+
+            var page1 = collection.Get(limit: 3, offset: 0);
+            var page2 = collection.Get(limit: 3, offset: 3);
+
+            Assert.AreEqual(3, page1.Ids.Count);
+            Assert.AreEqual(3, page2.Ids.Count);
+
+            var allIds = page1.Ids.Concat(page2.Ids).ToList();
+            Assert.AreEqual(6, allIds.Distinct().Count(), "Pages should not overlap");
+        }
+
+        [TestMethod]
+        public void QueryResult_Enumerable_Works()
+        {
+            using var client = new ChromaClient(persistDirectory: _testDir);
+            using var collection = client.CreateCollectionWithUniqueName(embeddingFunction: _embeddingFunction);
+
+            collection.Add("doc1", "First",
+                new Dictionary<string, object> { ["order"] = 1 });
+            collection.Add("doc2", "Second",
+                new Dictionary<string, object> { ["order"] = 2 });
+
+            var results = collection.Get();
+
+            int count = 0;
+            foreach (var doc in results)
+            {
+                Assert.IsNotNull(doc.Id);
+                Assert.IsNotNull(doc.Text);
+                count++;
+            }
+            Assert.AreEqual(2, count);
+
+            var ids = results.Select(d => d.Id).ToList();
+            Assert.AreEqual(2, ids.Count);
+        }
+
+        [TestMethod]
+        public void EmptyCollection_Query_ReturnsEmptyResults()
+        {
+            using var client = new ChromaClient(persistDirectory: _testDir);
+            using var collection = client.CreateCollectionWithUniqueName(embeddingFunction: _embeddingFunction);
+
+            Assert.AreEqual<uint>(0, collection.Count());
+
+            var results = collection.Query(queryText: "anything", nResults: 5);
+            Assert.AreEqual(0, results.Ids.Count);
+        }
+
+        [TestMethod]
+        public void Delete_WithWhereFilter_DeletesMatchingDocuments()
+        {
+            using var client = new ChromaClient(persistDirectory: _testDir);
+            using var collection = client.CreateCollectionWithUniqueName(embeddingFunction: _embeddingFunction);
+
+            collection.Add("doc1", "Keep this",
+                new Dictionary<string, object> { ["status"] = "keep" });
+            collection.Add("doc2", "Delete this",
+                new Dictionary<string, object> { ["status"] = "delete" });
+            collection.Add("doc3", "Also delete",
+                new Dictionary<string, object> { ["status"] = "delete" });
+
+            Assert.AreEqual<uint>(3, collection.Count());
+
+            collection.Delete(
+                whereFilter: new Dictionary<string, object> { ["status"] = "delete" });
+
+            Assert.AreEqual<uint>(1, collection.Count());
+            var remaining = collection.Get();
+            Assert.AreEqual("doc1", remaining.Ids[0]);
+        }
+
+        [TestMethod]
+        public void Add_EmptyList_DoesNotThrow()
+        {
+            using var client = new ChromaClient(persistDirectory: _testDir);
+            using var collection = client.CreateCollectionWithUniqueName(embeddingFunction: _embeddingFunction);
+
+            collection.Add(new List<ChromaDocument>());
+            Assert.AreEqual<uint>(0, collection.Count());
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Delete_NoArguments_ThrowsArgumentException()
+        {
+            using var client = new ChromaClient(persistDirectory: _testDir);
+            using var collection = client.CreateCollectionWithUniqueName(embeddingFunction: _embeddingFunction);
+
+            collection.Delete();
+        }
+
+        [TestMethod]
+        public void GetById_NonExistent_ReturnsNull()
+        {
+            using var client = new ChromaClient(persistDirectory: _testDir);
+            using var collection = client.CreateCollectionWithUniqueName(embeddingFunction: _embeddingFunction);
+
+            var doc = collection.GetById("does-not-exist");
+            Assert.IsNull(doc);
+        }
+
+        [TestMethod]
+        public void Delete_NonExistentId_DoesNotThrow()
+        {
+            using var client = new ChromaClient(persistDirectory: _testDir);
+            using var collection = client.CreateCollectionWithUniqueName(embeddingFunction: _embeddingFunction);
+
+            collection.Add("doc1", "exists",
+                new Dictionary<string, object> { ["k"] = "v" });
+
+            collection.Delete("does-not-exist");
+
+            Assert.AreEqual<uint>(1, collection.Count());
+        }
+    }
+}

--- a/Tests/ChromaDB.NET.Tests/ChromaDB.NET.Tests.csproj
+++ b/Tests/ChromaDB.NET.Tests/ChromaDB.NET.Tests.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <!-- Add native library handling properties -->
-    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-arm64</RuntimeIdentifiers>
     <!-- Explicitly set where to look for native libraries -->
     <NativeLibraryDirectories>$(MSBuildThisFileDirectory)..\..\runtimes</NativeLibraryDirectories>
   </PropertyGroup>

--- a/Tests/ChromaDB.NET.Tests/DisposeSafetyTests.cs
+++ b/Tests/ChromaDB.NET.Tests/DisposeSafetyTests.cs
@@ -174,7 +174,8 @@ namespace ChromaDB.NET.Tests
                 });
             }
 
-            Task.WaitAll(tasks);
+            if (!Task.WaitAll(tasks, TimeSpan.FromSeconds(30)))
+                Assert.Fail("Concurrent operations timed out after 30 seconds");
 
             for (int i = 0; i < errors.Length; i++)
             {

--- a/Tests/ChromaDB.NET.Tests/DisposeSafetyTests.cs
+++ b/Tests/ChromaDB.NET.Tests/DisposeSafetyTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ChromaDB.NET.Tests
+{
+    [TestClass]
+    public class DisposeSafetyTests
+    {
+        private string _testDir = string.Empty;
+        private TestEmbeddingFunction _embeddingFunction = new TestEmbeddingFunction();
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _testDir = Path.Combine(Path.GetTempPath(), "chromadb-dotnet-tests", Guid.NewGuid().ToString());
+            Directory.CreateDirectory(_testDir);
+            _embeddingFunction = new TestEmbeddingFunction();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            try
+            {
+                if (Directory.Exists(_testDir))
+                {
+                    Thread.Sleep(100);
+                    Directory.Delete(_testDir, true);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error cleaning up test directory '{_testDir}': {ex.Message}");
+            }
+        }
+
+        [TestMethod]
+        public void Client_UseAfterDispose_ThrowsObjectDisposedException()
+        {
+            var client = new ChromaClient(persistDirectory: _testDir);
+            client.Dispose();
+
+            Assert.ThrowsException<ObjectDisposedException>(() => client.Heartbeat());
+        }
+
+        [TestMethod]
+        public void Client_DoubleDispose_DoesNotThrow()
+        {
+            var client = new ChromaClient(persistDirectory: _testDir);
+            client.Dispose();
+            client.Dispose();
+        }
+
+        [TestMethod]
+        public void Collection_UseAfterDispose_ThrowsObjectDisposedException()
+        {
+            using var client = new ChromaClient(persistDirectory: _testDir);
+            var collection = client.CreateCollectionWithUniqueName(embeddingFunction: _embeddingFunction);
+            collection.Dispose();
+
+            Assert.ThrowsException<ObjectDisposedException>(() => collection.Count());
+        }
+
+        [TestMethod]
+        public void Collection_DoubleDispose_DoesNotThrow()
+        {
+            using var client = new ChromaClient(persistDirectory: _testDir);
+            var collection = client.CreateCollectionWithUniqueName(embeddingFunction: _embeddingFunction);
+            collection.Dispose();
+            collection.Dispose();
+        }
+
+        [TestMethod]
+        public void Collection_UseAfterClientDispose_ThrowsObjectDisposedException()
+        {
+            var client = new ChromaClient(persistDirectory: _testDir);
+            var collection = client.CreateCollectionWithUniqueName(embeddingFunction: _embeddingFunction);
+            client.Dispose();
+
+            Assert.ThrowsException<ObjectDisposedException>(() => collection.Count());
+            collection.Dispose();
+        }
+
+        [TestMethod]
+        public void Client_CreateCollection_AfterDispose_ThrowsObjectDisposedException()
+        {
+            var client = new ChromaClient(persistDirectory: _testDir);
+            client.Dispose();
+
+            Assert.ThrowsException<ObjectDisposedException>(
+                () => client.CreateCollection("test", _embeddingFunction));
+        }
+
+        [TestMethod]
+        public void Client_GetCollection_AfterDispose_ThrowsObjectDisposedException()
+        {
+            var client = new ChromaClient(persistDirectory: _testDir);
+            client.Dispose();
+
+            Assert.ThrowsException<ObjectDisposedException>(
+                () => client.GetCollection("test", _embeddingFunction));
+        }
+
+        [TestMethod]
+        public void Client_DatabaseOps_AfterDispose_ThrowsObjectDisposedException()
+        {
+            var client = new ChromaClient(persistDirectory: _testDir);
+            client.Dispose();
+
+            Assert.ThrowsException<ObjectDisposedException>(
+                () => client.CreateDatabase("test-db"));
+            Assert.ThrowsException<ObjectDisposedException>(
+                () => client.GetDatabaseId("test-db"));
+            Assert.ThrowsException<ObjectDisposedException>(
+                () => client.DeleteDatabase("test-db"));
+        }
+
+        [TestMethod]
+        public void Collection_AllOps_AfterDispose_ThrowObjectDisposedException()
+        {
+            using var client = new ChromaClient(persistDirectory: _testDir);
+            var collection = client.CreateCollectionWithUniqueName(embeddingFunction: _embeddingFunction);
+            collection.Dispose();
+
+            Assert.ThrowsException<ObjectDisposedException>(() => collection.Count());
+            Assert.ThrowsException<ObjectDisposedException>(
+                () => collection.Add("id", "text"));
+            Assert.ThrowsException<ObjectDisposedException>(
+                () => collection.Query("text"));
+            Assert.ThrowsException<ObjectDisposedException>(
+                () => collection.Get());
+            Assert.ThrowsException<ObjectDisposedException>(
+                () => collection.Delete("id"));
+            Assert.ThrowsException<ObjectDisposedException>(
+                () => collection.Update("id", "text"));
+            Assert.ThrowsException<ObjectDisposedException>(
+                () => collection.Upsert("id", "text"));
+            Assert.ThrowsException<ObjectDisposedException>(
+                () => collection.Where(new WhereFilter().Equals("k", "v")));
+            Assert.ThrowsException<ObjectDisposedException>(
+                () => collection.Search("text"));
+        }
+
+        [TestMethod]
+        public void ConcurrentOperations_DoNotCrash()
+        {
+            using var client = new ChromaClient(persistDirectory: _testDir);
+            using var collection = client.CreateCollectionWithUniqueName(embeddingFunction: _embeddingFunction);
+
+            collection.Add("seed", "seed document",
+                new System.Collections.Generic.Dictionary<string, object> { ["k"] = "v" });
+
+            var tasks = new Task[10];
+            var errors = new Exception[10];
+
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                int idx = i;
+                tasks[i] = Task.Run(() =>
+                {
+                    try
+                    {
+                        collection.Count();
+                        collection.Get();
+                        collection.Query(queryText: "seed", nResults: 1);
+                    }
+                    catch (Exception ex)
+                    {
+                        errors[idx] = ex;
+                    }
+                });
+            }
+
+            Task.WaitAll(tasks);
+
+            for (int i = 0; i < errors.Length; i++)
+            {
+                if (errors[i] != null)
+                    Assert.Fail($"Task {i} threw: {errors[i]}");
+            }
+        }
+    }
+}

--- a/build.ps1
+++ b/build.ps1
@@ -1,28 +1,23 @@
 # PowerShell build script for ChromaDB C# bindings
 $ErrorActionPreference = "Stop"
 
-# Script directories
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $OutputDir = Join-Path $ScriptDir "runtimes"
 
-# Create output directories for each platform
 New-Item -ItemType Directory -Force -Path (Join-Path $OutputDir "win-x64\native")
 New-Item -ItemType Directory -Force -Path (Join-Path $OutputDir "linux-x64\native")
-New-Item -ItemType Directory -Force -Path (Join-Path $OutputDir "osx-x64\native")
 New-Item -ItemType Directory -Force -Path (Join-Path $OutputDir "osx-arm64\native")
 
 Write-Host "Building ChromaDB C# bindings for multiple platforms..."
 
-# Check if we're on Windows
 if ($IsWindows -or $env:OS -match "Windows") {
     # Build for Windows x64
     Write-Host "Building for Windows x64..."
     cargo build --release
     Copy-Item "$ScriptDir\target\release\chroma_csharp.dll" -Destination "$OutputDir\win-x64\native\" -Force
-    
-    # Check if other targets are installed
+
     $targets = rustup target list --installed
-    
+
     # Cross-compile for Linux (if target installed)
     if ($targets -match "x86_64-unknown-linux-gnu") {
         Write-Host "Building for Linux x64..."
@@ -32,17 +27,8 @@ if ($IsWindows -or $env:OS -match "Windows") {
         Write-Host "Linux target not installed. Skipping Linux build."
         Write-Host "To install: rustup target add x86_64-unknown-linux-gnu"
     }
-    
-    # Cross-compile for macOS (if targets installed)
-    if ($targets -match "x86_64-apple-darwin") {
-        Write-Host "Building for macOS x64..."
-        cargo build --release --target x86_64-apple-darwin
-        Copy-Item "$ScriptDir\target\x86_64-apple-darwin\release\libchroma_csharp.dylib" -Destination "$OutputDir\osx-x64\native\" -Force
-    } else {
-        Write-Host "macOS x64 target not installed. Skipping macOS x64 build."
-        Write-Host "To install: rustup target add x86_64-apple-darwin"
-    }
-    
+
+    # Cross-compile for macOS ARM64 (if target installed)
     if ($targets -match "aarch64-apple-darwin") {
         Write-Host "Building for macOS ARM64..."
         cargo build --release --target aarch64-apple-darwin

--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
 set -e
 
-# Build script for ChromaDB C# bindings
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# ROOT_DIR is the same as SCRIPT_DIR for this project structure
 OUTPUT_DIR="$SCRIPT_DIR/runtimes"
 
-# Create output directories for each platform
 mkdir -p "$OUTPUT_DIR/win-x64/native"
 mkdir -p "$OUTPUT_DIR/linux-x64/native"
-mkdir -p "$OUTPUT_DIR/osx-x64/native"
 mkdir -p "$OUTPUT_DIR/osx-arm64/native"
 
 echo "Building ChromaDB C# bindings for multiple platforms..."
@@ -17,32 +13,23 @@ echo "Building ChromaDB C# bindings for multiple platforms..."
 # Build for Linux x64
 echo "Building for Linux x64..."
 cargo build --release
-cp "$SCRIPT_DIR/target/release/libchroma_csharp.so" "$OUTPUT_DIR/linux-x64/native/" # Corrected source path
+cp "$SCRIPT_DIR/target/release/libchroma_csharp.so" "$OUTPUT_DIR/linux-x64/native/"
 
 # Cross-compile for Windows (requires appropriate target)
 if rustup target list --installed | grep -q "x86_64-pc-windows-msvc"; then
     echo "Building for Windows x64..."
     cargo build --release --target x86_64-pc-windows-msvc
-    cp "$SCRIPT_DIR/target/x86_64-pc-windows-msvc/release/chroma_csharp.dll" "$OUTPUT_DIR/win-x64/native/" # Corrected source path
+    cp "$SCRIPT_DIR/target/x86_64-pc-windows-msvc/release/chroma_csharp.dll" "$OUTPUT_DIR/win-x64/native/"
 else
     echo "Windows target not installed. Skipping Windows build."
     echo "To install: rustup target add x86_64-pc-windows-msvc"
 fi
 
-# Cross-compile for macOS (requires appropriate targets)
-if rustup target list --installed | grep -q "x86_64-apple-darwin"; then
-    echo "Building for macOS x64..."
-    cargo build --release --target x86_64-apple-darwin
-    cp "$SCRIPT_DIR/target/x86_64-apple-darwin/release/libchroma_csharp.dylib" "$OUTPUT_DIR/osx-x64/native/" # Corrected source path
-else
-    echo "macOS x64 target not installed. Skipping macOS x64 build."
-    echo "To install: rustup target add x86_64-apple-darwin"
-fi
-
+# Cross-compile for macOS ARM64 (requires appropriate target)
 if rustup target list --installed | grep -q "aarch64-apple-darwin"; then
     echo "Building for macOS ARM64..."
     cargo build --release --target aarch64-apple-darwin
-    cp "$SCRIPT_DIR/target/aarch64-apple-darwin/release/libchroma_csharp.dylib" "$OUTPUT_DIR/osx-arm64/native/" # Corrected source path
+    cp "$SCRIPT_DIR/target/aarch64-apple-darwin/release/libchroma_csharp.dylib" "$OUTPUT_DIR/osx-arm64/native/"
 else
     echo "macOS ARM64 target not installed. Skipping macOS ARM64 build."
     echo "To install: rustup target add aarch64-apple-darwin"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.92.0"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -14,11 +14,10 @@ use chroma_sqlite::config::{MigrationHash, MigrationMode, SqliteDBConfig};
 use chroma_sysdb::{SqliteSysDbConfig, SysDbConfig};
 use chroma_system::System;
 use chroma_types::{
-    CreateDatabaseRequest, DeleteDatabaseRequest, GetDatabaseRequest, KnnIndex,
+    CreateDatabaseRequest, DatabaseName, DeleteDatabaseRequest, GetDatabaseRequest, KnnIndex,
 };
 use libc::{c_char, c_int, size_t};
 use std::time::SystemTime;
-use std::path::Path;
 use tokio::runtime::Runtime;
 
 use crate::error::{set_error, set_success, ChromaErrorCode, ChromaError};
@@ -62,7 +61,7 @@ pub extern "C" fn chroma_create_client(
         unsafe {
             let sqlite_config = &*sqlite_config_ptr;
 
-            let url = match c_str_to_string(sqlite_config.url) {
+            let _url = match c_str_to_string(sqlite_config.url) {
                 Ok(s) => s,
                 Err(e) => {
                     set_error(
@@ -214,12 +213,18 @@ pub extern "C" fn chroma_create_client(
         segment_manager: Some(segment_manager_config),
         sqlitedb: Some(sqlite_db_config),
         sysdb: sysdb_config,
+        mcmr_sysdb: None,
         collections_with_segments_provider: collection_cache_config,
         log: log_config,
         executor: executor_config,
         default_knn_index: knn_index,
-            tenants_to_migrate_immediately: vec![],
-            tenants_to_migrate_immediately_threshold: None,
+        tenants_to_migrate_immediately: vec![],
+        tenants_to_migrate_immediately_threshold: None,
+        enable_schema: false,
+        min_records_for_invocation: 0,
+        tenants_with_quantization_enabled: vec![],
+        tenants_with_maxscore_enabled: vec![],
+        enable_log_scouting: false,
     };
 
     // Create frontend
@@ -397,10 +402,24 @@ pub extern "C" fn chroma_create_database(
     };
 
     // Get client reference
-    let client = unsafe { &mut *client_handle };
+    let client = unsafe { &*client_handle };
+
+    let db_name = match DatabaseName::new(name) {
+        Some(n) => n,
+        None => {
+            set_error(
+                error_out,
+                ChromaErrorCode::ValidationError,
+                "Invalid database name (must be at least 3 characters)",
+                func_name,
+                None,
+            );
+            return ChromaErrorCode::ValidationError as c_int;
+        }
+    };
 
     // Create database request
-    let request = match CreateDatabaseRequest::try_new(tenant, name) {
+    let request = match CreateDatabaseRequest::try_new(tenant, db_name) {
         Ok(req) => req,
         Err(e) => {
             set_error(
@@ -505,9 +524,23 @@ pub extern "C" fn chroma_get_database(
         DEFAULT_TENANT.to_string()
     };
 
-    let client = unsafe { &mut *client_handle };
+    let client = unsafe { &*client_handle };
 
-    let request = match GetDatabaseRequest::try_new(tenant, name) {
+    let db_name = match DatabaseName::new(name) {
+        Some(n) => n,
+        None => {
+            set_error(
+                error_out,
+                ChromaErrorCode::ValidationError,
+                "Invalid database name (must be at least 3 characters)",
+                func_name,
+                None,
+            );
+            return ChromaErrorCode::ValidationError as c_int;
+        }
+    };
+
+    let request = match GetDatabaseRequest::try_new(tenant, db_name) {
         Ok(req) => req,
         Err(e) => {
             set_error(
@@ -610,7 +643,7 @@ pub extern "C" fn chroma_delete_database(
         DEFAULT_TENANT.to_string()
     };
 
-    let client = unsafe { &mut *client_handle };
+    let client = unsafe { &*client_handle };
 
     let request = match DeleteDatabaseRequest::try_new(tenant, name) {
         Ok(req) => req,

--- a/src/collection/management.rs
+++ b/src/collection/management.rs
@@ -1,6 +1,6 @@
 // Collection management functions for ChromaDB C# bindings
 use chroma_types::{
-    CollectionConfiguration, CreateCollectionRequest, GetCollectionRequest,
+    CollectionConfiguration, CreateCollectionRequest, DatabaseName, GetCollectionRequest,
     InternalCollectionConfiguration, Metadata,
 };
 use libc::{c_char, c_int};
@@ -104,6 +104,20 @@ pub extern "C" fn chroma_create_collection(
         DEFAULT_DATABASE.to_string()
     };
 
+    let database_name = match DatabaseName::new(database.clone()) {
+        Some(n) => n,
+        None => {
+            set_error(
+                error_out,
+                ChromaErrorCode::ValidationError,
+                "Invalid database name (must be at least 3 characters)",
+                func_name,
+                None,
+            );
+            return ChromaErrorCode::ValidationError as c_int;
+        }
+    };
+
     // Parse configuration JSON if provided
     let configuration_json = if !config_json_ptr.is_null() {
         unsafe {
@@ -174,7 +188,7 @@ pub extern "C" fn chroma_create_collection(
         None
     };
 
-    let client = unsafe { &mut *client_handle };
+    let client = unsafe { &*client_handle };
 
     // Convert configuration to internal format
     let configuration = match configuration_json {
@@ -203,10 +217,11 @@ pub extern "C" fn chroma_create_collection(
     // Create the collection request
     let request = match CreateCollectionRequest::try_new(
         tenant.clone(),
-        database.clone(),
+        database_name,
         name,
         metadata,
         configuration,
+        None, // schema
         get_or_create,
     ) {
         Ok(req) => req,
@@ -346,9 +361,23 @@ pub extern "C" fn chroma_get_collection(
         DEFAULT_DATABASE.to_string()
     };
 
-    let client = unsafe { &mut *client_handle };
+    let database_name = match DatabaseName::new(database.clone()) {
+        Some(n) => n,
+        None => {
+            set_error(
+                error_out,
+                ChromaErrorCode::ValidationError,
+                "Invalid database name (must be at least 3 characters)",
+                func_name,
+                None,
+            );
+            return ChromaErrorCode::ValidationError as c_int;
+        }
+    };
 
-    let request = match GetCollectionRequest::try_new(tenant.clone(), database.clone(), name) {
+    let client = unsafe { &*client_handle };
+
+    let request = match GetCollectionRequest::try_new(tenant.clone(), database_name, name) {
         Ok(req) => req,
         Err(e) => {
             set_error(

--- a/src/collection/operations.rs
+++ b/src/collection/operations.rs
@@ -2,6 +2,7 @@
 use chroma_types::{
     AddCollectionRecordsRequest, CollectionUuid, CountRequest, DeleteCollectionRecordsRequest,
     GetRequest, IncludeList, Metadata, QueryRequest, RawWhereFields,
+    plan::ReadLevel,
     UpdateCollectionRecordsRequest, UpdateMetadata, UpsertCollectionRecordsRequest,
 };
 use libc::{c_char, c_float, c_int, c_uint, size_t};
@@ -54,7 +55,7 @@ pub extern "C" fn chroma_add(
         return ChromaErrorCode::InvalidArgument as c_int;
     }
 
-    let client = unsafe { &mut *client_handle };
+    let client = unsafe { &*client_handle };
     let collection = unsafe { &*collection_handle };
 
     // Convert C string array to Rust vector
@@ -74,7 +75,7 @@ pub extern "C" fn chroma_add(
         }
     };
 
-    // Convert C embedding array to Rust vector
+    // Convert C embedding array to Rust vector (required for add)
     let embeddings_vec = if !embeddings.is_null() {
         let mut result = Vec::with_capacity(ids_count);
         unsafe {
@@ -94,7 +95,7 @@ pub extern "C" fn chroma_add(
                 }
             }
         }
-        Some(result)
+        result
     } else {
         set_error(
             error_out,
@@ -281,7 +282,7 @@ pub extern "C" fn chroma_count(
         return ChromaErrorCode::InvalidArgument as c_int;
     }
 
-    let client = unsafe { &mut *client_handle };
+    let client = unsafe { &*client_handle };
     let collection = unsafe { &*collection_handle };
 
     // Parse collection ID
@@ -304,6 +305,7 @@ pub extern "C" fn chroma_count(
         collection.tenant.clone(),
         collection.database.clone(),
         collection_id,
+        ReadLevel::default(),
     ) {
         Ok(req) => req,
         Err(e) => {
@@ -380,7 +382,7 @@ pub extern "C" fn chroma_update(
         return ChromaErrorCode::InvalidArgument as c_int;
     }
 
-    let client = unsafe { &mut *client_handle };
+    let client = unsafe { &*client_handle };
     let collection = unsafe { &*collection_handle };
 
     // Convert C string array to Rust vector
@@ -601,7 +603,7 @@ pub extern "C" fn chroma_upsert(
         return ChromaErrorCode::InvalidArgument as c_int;
     }
 
-    let client = unsafe { &mut *client_handle };
+    let client = unsafe { &*client_handle };
     let collection = unsafe { &*collection_handle };
 
     // Convert C string array to Rust vector
@@ -621,7 +623,7 @@ pub extern "C" fn chroma_upsert(
         }
     };
 
-    // Convert C embedding array to Rust vector
+    // Convert C embedding array to Rust vector (required for upsert)
     let embeddings_vec = if !embeddings.is_null() {
         let mut result = Vec::with_capacity(ids_count);
         unsafe {
@@ -641,9 +643,16 @@ pub extern "C" fn chroma_upsert(
                 }
             }
         }
-        Some(result)
+        result
     } else {
-        None
+        set_error(
+            error_out,
+            ChromaErrorCode::InvalidArgument,
+            "Embeddings pointer is null",
+            func_name,
+            None,
+        );
+        return ChromaErrorCode::InvalidArgument as c_int;
     };
 
     // Convert metadata JSON strings to Rust vector
@@ -834,7 +843,7 @@ pub extern "C" fn chroma_delete(
         return ChromaErrorCode::InvalidArgument as c_int;
     }
 
-    let client = unsafe { &mut *client_handle };
+    let client = unsafe { &*client_handle };
     let collection = unsafe { &*collection_handle };
 
     // Convert C string array to Rust vector
@@ -954,6 +963,7 @@ pub extern "C" fn chroma_delete(
         collection_id,
         ids_vec,
         where_filter,
+        None, // limit
     ) {
         Ok(req) => req,
         Err(e) => {
@@ -972,7 +982,7 @@ pub extern "C" fn chroma_delete(
     let mut frontend = client.frontend.clone();
     match client
         .runtime
-        .block_on(async { frontend.delete(request).await })
+        .block_on(async { frontend.delete(request, String::new()).await })
     {
         Ok(_) => {
             set_success(error_out);
@@ -1029,7 +1039,7 @@ pub extern "C" fn chroma_get(
         return ChromaErrorCode::InvalidArgument as c_int;
     }
 
-    let client = unsafe { &mut *client_handle };
+    let client = unsafe { &*client_handle };
     let collection = unsafe { &*collection_handle };
 
     // Convert C string array to Rust vector
@@ -1316,7 +1326,7 @@ pub extern "C" fn chroma_query(
         return ChromaErrorCode::InvalidArgument as c_int;
     }
 
-    let client = unsafe { &mut *client_handle };
+    let client = unsafe { &*client_handle };
     let collection = unsafe { &*collection_handle };
 
     // Parse collection ID

--- a/src/collection/types.rs
+++ b/src/collection/types.rs
@@ -1,24 +1,33 @@
-// Type definitions for ChromaDB collection
+use libc::c_int;
 
-/// Collection handle for ChromaDB
-#[repr(C)]
+use crate::error::{set_error, set_success, ChromaError, ChromaErrorCode};
+
 pub struct ChromaCollection {
     pub(crate) id: String,
     pub(crate) tenant: String,
     pub(crate) database: String,
 }
 
-/// Frees memory allocated for ChromaCollection
 #[no_mangle]
-pub extern "C" fn chroma_destroy_collection(collection_handle: *mut ChromaCollection) -> i32 {
-    use crate::error::ChromaErrorCode;
-
-    if !collection_handle.is_null() {
-        unsafe {
-            let _ = Box::from_raw(collection_handle);
-        }
-        ChromaErrorCode::Success as i32
-    } else {
-        ChromaErrorCode::InvalidArgument as i32
+pub extern "C" fn chroma_destroy_collection(
+    collection_handle: *mut ChromaCollection,
+    error_out: *mut *mut ChromaError,
+) -> c_int {
+    if collection_handle.is_null() {
+        set_error(
+            error_out,
+            ChromaErrorCode::InvalidArgument,
+            "Collection handle pointer is null",
+            "chroma_destroy_collection",
+            None,
+        );
+        return ChromaErrorCode::InvalidArgument as c_int;
     }
+
+    unsafe {
+        let _ = Box::from_raw(collection_handle);
+    }
+
+    set_success(error_out);
+    ChromaErrorCode::Success as c_int
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,9 +1,7 @@
-// Error handling module for ChromaDB C# bindings
 use libc::c_char;
 use std::ffi::CString;
 use std::ptr;
 
-/// Error codes for ChromaDB C API
 #[repr(C)]
 pub enum ChromaErrorCode {
     Success = 0,
@@ -16,21 +14,15 @@ pub enum ChromaErrorCode {
     NotImplemented = 7,
 }
 
-/// Detailed error information for ChromaDB C API
 #[repr(C)]
 pub struct ChromaError {
-    /// Error code
     pub code: ChromaErrorCode,
-    /// Error message
     pub message: *mut c_char,
-    /// Source of the error (e.g., function name)
     pub source: *mut c_char,
-    /// Details about the error (additional context)
     pub details: *mut c_char,
 }
 
 impl ChromaError {
-    /// Creates a new error object
     pub fn new(code: ChromaErrorCode, message: &str, source: &str, details: Option<&str>) -> Self {
         ChromaError {
             code,
@@ -42,19 +34,8 @@ impl ChromaError {
             },
         }
     }
-
-    /// Creates a success result
-    pub fn success() -> Self {
-        ChromaError {
-            code: ChromaErrorCode::Success,
-            message: ptr::null_mut(),
-            source: ptr::null_mut(),
-            details: ptr::null_mut(),
-        }
-    }
 }
 
-/// Helper function to set error out parameter
 pub fn set_error(
     error_out: *mut *mut ChromaError,
     code: ChromaErrorCode,
@@ -70,39 +51,31 @@ pub fn set_error(
     }
 }
 
-/// Helper function to set success result
 pub fn set_success(error_out: *mut *mut ChromaError) {
     if !error_out.is_null() {
-        let error = Box::new(ChromaError::success());
         unsafe {
-            *error_out = Box::into_raw(error);
+            *error_out = ptr::null_mut();
         }
     }
 }
 
-/// Frees memory allocated for ChromaError
 #[no_mangle]
 pub extern "C" fn chroma_free_error(error: *mut ChromaError) {
     if !error.is_null() {
         unsafe {
-            let error = &mut *error;
+            let error = Box::from_raw(error);
 
             if !error.message.is_null() {
                 let _ = CString::from_raw(error.message);
-                error.message = ptr::null_mut();
             }
 
             if !error.source.is_null() {
                 let _ = CString::from_raw(error.source);
-                error.source = ptr::null_mut();
             }
 
             if !error.details.is_null() {
                 let _ = CString::from_raw(error.details);
-                error.details = ptr::null_mut();
             }
-
-            libc::free(error as *mut ChromaError as *mut libc::c_void);
         }
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,7 +1,5 @@
-// Type definitions for ChromaDB C# bindings
 use libc::{c_char, c_float, c_int, size_t};
 
-/// Configuration for SQLite database
 #[repr(C)]
 pub struct SqliteConfigFFI {
     pub url: *const c_char,
@@ -9,7 +7,6 @@ pub struct SqliteConfigFFI {
     pub migration_mode: c_int,
 }
 
-/// Response from query operations
 #[repr(C)]
 pub struct ChromaQueryResult {
     pub ids: *mut *mut c_char,
@@ -22,26 +19,23 @@ pub struct ChromaQueryResult {
     pub documents_count: size_t,
 }
 
-/// Embedding vector
 #[repr(C)]
 pub struct ChromaEmbedding {
     pub values: *const c_float,
     pub dimension: size_t,
 }
 
-/// Result set information for ChromaDB operations
 #[repr(C)]
 pub struct ChromaResultSet {
     pub ids: *mut *mut c_char,
     pub count: size_t,
 }
 
-/// Frees memory allocated for ChromaQueryResult
 #[no_mangle]
 pub extern "C" fn chroma_free_query_result(result: *mut ChromaQueryResult) {
     if !result.is_null() {
         unsafe {
-            let result = &mut *result;
+            let result = Box::from_raw(result);
 
             crate::utils::chroma_free_string_array(result.ids, result.ids_count);
 
@@ -51,8 +45,6 @@ pub extern "C" fn chroma_free_query_result(result: *mut ChromaQueryResult) {
 
             crate::utils::chroma_free_string_array(result.metadata_json, result.metadata_count);
             crate::utils::chroma_free_string_array(result.documents, result.documents_count);
-
-            libc::free(result as *mut ChromaQueryResult as *mut libc::c_void);
         }
     }
 }


### PR DESCRIPTION
## Summary
- **Upgrade ChromaDB Rust core** from 1.0.15 to 1.5.9 (40+ releases), adapting to all breaking API changes (DatabaseName newtype, required embeddings, ReadLevel, delete limit, schema param, 6 new FrontendConfig fields). Pin Rust toolchain to 1.92.0.
- **Fix critical memory safety bugs**: `Box`-allocated memory freed with `libc::free` (UB), `#[repr(C)]` on struct with `String` fields, ABI mismatches between Rust and C# for `chroma_free_error`/`chroma_destroy_collection`, `set_success` allocating on every call, `GetOrCreateCollection` swallowing all exceptions.
- **Add thread safety**: Change all `&mut *client_handle` to `&*client_handle` in Rust FFI (shared ref suffices since Frontend is cloned per-call), add `Interlocked.Exchange` dispose pattern and `ObjectDisposedException` guards in C# `ChromaClient` and `Collection`.
- **Expand test suite** from 66 to 92 tests covering dispose safety, concurrent operations, batch adds, pagination, `$ne`/`$contains` filters, heartbeat, and edge cases.

## Test plan
- [x] `cargo check` — zero errors, zero warnings
- [x] `dotnet build` — zero errors
- [x] `dotnet test` — 92/92 pass
- [ ] Manual smoke test on Windows/macOS after native lib rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)